### PR TITLE
GITHUB_TOKEN to PATNAME

### DIFF
--- a/.github/WORKFLOWS_GUIDE.md
+++ b/.github/WORKFLOWS_GUIDE.md
@@ -241,7 +241,7 @@ Template for PR descriptions and checklist
 
 ## 🔐 Security Notes
 
-- Workflows use `secrets.GITHUB_TOKEN` (minimum required permissions)
+- Workflows use `secrets.PATNAME` (minimum required permissions)
 - No credentials stored in workflow files
 - Security scans check for vulnerabilities
 - Dependabot updates include security patches

--- a/.github/workflows/build-docker-on-pr.yml
+++ b/.github/workflows/build-docker-on-pr.yml
@@ -98,7 +98,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.PATNAME }}
 
       - name: Extract metadata
         id: meta

--- a/.github/workflows/build-docker-on-tag.yml
+++ b/.github/workflows/build-docker-on-tag.yml
@@ -93,7 +93,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.PATNAME }}
 
       - name: Extract metadata
         id: meta

--- a/.github/workflows/monthly-test-and-tag.yml
+++ b/.github/workflows/monthly-test-and-tag.yml
@@ -89,7 +89,7 @@ jobs:
         id: tag_version
         uses: mathieudutour/github-tag-action@v6.2
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.PATNAME }}
           create_annotated_tag: true
 
       - name: Create a GitHub release

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/stale@v10
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ secrets.PATNAME }}
           stale-issue-message: 'This issue has been automatically marked as stale because it has not had recent activity.'
           stale-pr-message: 'This PR has been automatically marked as stale because it has not had recent activity.'
           stale-issue-label: 'stale'

--- a/.github/workflows/tag-repo-on-commit.yml
+++ b/.github/workflows/tag-repo-on-commit.yml
@@ -103,7 +103,7 @@ jobs:
         id: tag_version
         uses: mathieudutour/github-tag-action@v6.2
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.PATNAME }}
           create_annotated_tag: true
           default_bump: patch
           release_branches: master

--- a/WORKFLOWS_TROUBLESHOOTING.md
+++ b/WORKFLOWS_TROUBLESHOOTING.md
@@ -43,10 +43,10 @@
 ### Issue: "Container push fails with authentication error"
 **Solutions:**
 
-1. **Verify GITHUB_TOKEN is available**
+1. **Verify PATNAME is available**
    ```bash
    # In workflow logs, check if token was properly passed
-   docker login -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }} ghcr.io
+   docker login -u ${{ github.actor }} -p ${{ secrets.PATNAME }} ghcr.io
    ```
 
 2. **Check repository visibility**


### PR DESCRIPTION
- The primary reason a tag creation action does not fire when triggered by another workflow is that GitHub Actions prevents recursive workflow runs when the default GITHUB_TOKEN is used. To protect against infinite loops, any events (like pushing a tag) performed by a workflow using the default GITHUB_TOKEN will not trigger subsequent workflows.
- Use a Personal Access Token (PAT): Create a [PAT with repo permissions](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token), store it as a [GitHub secret](https://docs.github.com/en/actions/security-guides/encrypted-secrets), and use it for the push operation.