### PR TITLE
Add ALARM_ZONE_STATE_ERROR constant and update state handling in get_…

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,9 +99,22 @@ Each data source requires specific setup in 1Password:
 - **Ecobee**: Authorization token in 1Password vault
 - **Davis Weather Station**: Network access credentials
 - **Honeywell Alarm**: Authentication credentials
+- **Home Assistant**: Authentication credentials and configured alarm zones
 - **SensorPush**: API credentials and gateway ID
 - **ThermoWorks**: API access credentials
 - **AprilAire**: Cloud account credentials
+
+### Home Assistant Alarm States
+
+For Home Assistant contact zones, the `closed` value in the `/weather` response is:
+
+| Value | Meaning |
+| --- | --- |
+| `1` | Zone is closed or safe. |
+| `0` | Zone is open. |
+| `-1` | Zone state could not be collected. This does not mark `all_zones_closed` as open. |
+
+`all_zones_closed` is set to `0` only when a contact zone is confirmed open. A zone collection error leaves this summary state unchanged.
 
 ## 🧪 Testing
 

--- a/src/stations/home_assistant.py
+++ b/src/stations/home_assistant.py
@@ -15,7 +15,7 @@ import utilities.connect as connect
 import re
 
 from utilities import conversions
-from weather.data import AlarmZone, ZONE_TYPE_DOOR, ZONE_TYPE_MOTION, ZONE_TYPE_GARAGE_DOOR, ZONE_TYPE_CONTACT, \
+from weather.data import AlarmZone, ALARM_ZONE_STATE_ERROR, ZONE_TYPE_DOOR, ZONE_TYPE_MOTION, ZONE_TYPE_GARAGE_DOOR, ZONE_TYPE_CONTACT, \
     CLIMATE_TYPE_ECOBEE_THERMOSTAT, CLIMATE_TYPE_ECOBEE_SENSOR, Door, DEFAULT_TEMPERATURE,ZONE_TYPE_BASIC,CLIMATE_TYPE_HUMIDITY
 
 CONNECT_ITEM_ID = os.getenv("HOME_ASSISTANT_CONNECT_ITEM_ID")
@@ -82,7 +82,7 @@ def get_garage_door(bearer_token, key, s):
 def get_on_off_state(bearer_token, key, s):
     sensor_data = get_sensor_data(bearer_token, key, s)
     if sensor_data is None:
-        return 0
+        return ALARM_ZONE_STATE_ERROR
     if sensor_data["state"] == "off" or sensor_data["state"] == "Safe":
         return 1
     else:

--- a/src/weather/data.py
+++ b/src/weather/data.py
@@ -3,6 +3,7 @@ import datetime as dt
 import json
 
 DEFAULT_TEMPERATURE = 'None'
+ALARM_ZONE_STATE_ERROR = -1
 ZONE_TYPE_CONTACT = 0
 ZONE_TYPE_MOTION = 1
 ZONE_TYPE_DOOR = 2

--- a/tests/test_home_assistant.py
+++ b/tests/test_home_assistant.py
@@ -139,7 +139,7 @@ class TestHomeAssistant(unittest.TestCase):
         with patch('stations.home_assistant.get_sensor_data') as mock_get:
             mock_get.return_value = None
             result = home_assistant.get_on_off_state("token", "entity", MagicMock())
-            self.assertEqual(result, 0)
+            self.assertEqual(result, data.ALARM_ZONE_STATE_ERROR)
 
     def test_get_locked_state_locked(self):
         """Test locked state when door is locked."""
@@ -487,6 +487,16 @@ class TestHomeAssistant(unittest.TestCase):
             mock_state.return_value = 0  # Open/not safe
             home_assistant.add_alarm_zone("token", "0|1|contact_sensor|Living Room", mock_home, MagicMock())
             self.assertEqual(mock_home.alarm.all_zones_closed, 0)
+
+    def test_add_alarm_zone_contact_failure_does_not_mark_open(self):
+        """Test a failed contact read does not change the alarm summary."""
+        mock_home = MagicMock()
+        mock_home.alarm.all_zones_closed = 1
+
+        with patch('stations.home_assistant.get_on_off_state', return_value=data.ALARM_ZONE_STATE_ERROR):
+            home_assistant.add_alarm_zone("token", "0|1|contact_sensor|Living Room", mock_home, MagicMock())
+
+        self.assertEqual(mock_home.alarm.all_zones_closed, 1)
 
     def test_add_alarm_zone_does_not_reset_open_contact_state(self):
         """Test later zones do not reset an open contact state."""


### PR DESCRIPTION
This pull request improves the handling and documentation of Home Assistant alarm zone states, particularly in how error states are managed and reported. The changes clarify the meaning of alarm zone values, introduce a dedicated error state constant, update the logic to use this constant, and add tests to ensure correct behavior when zone state collection fails.

**Documentation and Error State Handling:**

* Updated the `README.md` to document Home Assistant alarm zone states, including the meaning of `1`, `0`, and `-1` values and how `all_zones_closed` is affected by errors.
* Introduced a new constant `ALARM_ZONE_STATE_ERROR = -1` in `weather.data` to standardize error reporting for alarm zones.
* Updated `get_on_off_state` in `home_assistant.py` to return `ALARM_ZONE_STATE_ERROR` when sensor data is missing, instead of `0`, to distinguish errors from open states.
* Changed tests to expect `ALARM_ZONE_STATE_ERROR` for missing sensor data, ensuring error handling is validated.
* Added a test to verify that a failed contact sensor read does not incorrectly mark `all_zones_closed` as open, preserving the correct alarm summary state.## Description
Please include a summary of the changes and related context. Include any relevant motivation and context.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Performance improvement
- [ ] Code refactor
- [ ] CI/CD improvement

## Related Issue
Fixes # (issue)

## Testing
Please describe the tests you ran to verify your changes. Provide instructions so we can reproduce.

- [x] Unit tests pass
- [ ] Integration tests pass
- [ ] Existing tests still pass
- [ ] Added new tests for new functionality

### Test Coverage
- Test scenario 1: ...
- Test scenario 2: ...

## Screenshots (if applicable)
If your changes have a visual component, include screenshots or GIFs.

## Checklist
- [ ] My code follows the project's style guidelines (PEP 8)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] I have updated the CHANGELOG.md with my changes

## Breaking Changes
error state to alarm. -1|0|1. -1 is new it used to default to 0 on error causing all_zones_closed to be false.

## Migration Guide
If this PR has breaking changes, please provide a migration guide for users.

## Additional context
Add any other context about the pull request here.

## Reviewers
Please assign reviewers: @billbinaz

